### PR TITLE
Remove RunTests from REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
 julia 0.3
-RunTests
 Compat


### PR DESCRIPTION
That package is deprecated (will not be installable on Julia 0.4), and apparently no longer used here