### PR TITLE
Fix deprecation warnings and REQUIRE problem with 0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
 julia 0.3
-RunTests
 Compat

--- a/src/Node.jl
+++ b/src/Node.jl
@@ -1,36 +1,27 @@
 # include("EBNF.jl")
 
 immutable Node
-  name::String
-  value::String
-  first::Int
-  last::Int
-  children::Array #::Array{Node}
-  ruleType::Type
-  sym::Any
+    name::AbstractString
+    value::AbstractString
+    first::Int
+    last::Int
+    children::Array #::Array{Node}
+    ruleType::Type
+    sym::Any
 
-  function Node(node::Node)
-    return new(node.name, node.value, node.first, node.last, node.children, node.ruleType, node.sym)
-  end
+    Node(node::Node) =
+        new(node.name, node.value, node.first, node.last, node.children, node.ruleType, node.sym)
 
-  function Node(name::String, value::String, first::Int, last::Int, children::Array, ruleType::Type)
-    if length(name) == 0
-      sym = nothing
-    else
-      sym = symbol(name)
-    end
-
-    return new(name, value, first, last, children, ruleType, sym)
-  end
+    Node(name::AbstractString, value::AbstractString,
+         first::Int, last::Int, children::Array, ruleType::Type) =
+        new(name, value, first, last, children, ruleType,
+            length(name)==0 ? nothing : symbol(name))
 end
 
-function Node(name::String, value::String, first::Int, last::Int, typ)
-  return Node(name, value, first, last, [], typ)
-end
+Node(name::AbstractString, value::AbstractString, first::Int, last::Int, typ) =
+    Node(name, value, first, last, [], typ)
 
-function show{T}(io::IO, val::T, indent)
-  println(io, "$val ($(typeof(val)))")
-end
+show{T}(io::IO, val::T, indent) = println(io, "$val ($(typeof(val)))")
 
 function show(io::IO, node::Node, indent)
   println(io, "node($(node.name)) {$(displayValue(node.value, node.ruleType))$(node.ruleType)}")
@@ -46,6 +37,4 @@ function show(io::IO, node::Node, indent)
   end
 end
 
-function show(io::IO, node::Node)
-    show(io, node, 0)
-end
+show(io::IO, node::Node) = show(io, node, 0)

--- a/src/grammar.jl
+++ b/src/grammar.jl
@@ -21,7 +21,7 @@ type EmptyRule <: Rule
     return new("")
   end
 
-  function EmptyRule(name::String)
+  function EmptyRule(name::AbstractString)
     return new(name)
   end
 end
@@ -33,7 +33,7 @@ type ParserData
   ParserData(parsers) = new(parsers)
 end
 
-function parseDefinition(name::String, sym::Symbol, pdata::ParserData)
+function parseDefinition(name::AbstractString, sym::Symbol, pdata::ParserData)
   fn = get(pdata.parsers, sym, nothing)
 
   if fn !== nothing
@@ -68,7 +68,7 @@ end
 # FIXME: There is a weird mismatch in the parsers and parseDefinition..
 # should they really be different? if not, parseDefinition might need
 # to be changed to allow for arrays to be passed in
-function parseDefinition(name::String, expr::Expr, pdata::ParserData)
+function parseDefinition(name::AbstractString, expr::Expr, pdata::ParserData)
   rule = EmptyRule()
 
   # if it's a macro (e.g. r"regex", then we want to expand it first)


### PR DESCRIPTION
There were still many cases of `String`, which needed to be changed to `AbstractString`.
For a future PR, I think many of these should really be `UTF8String` (a concrete type),
rather than using an abstract type in a field definition.